### PR TITLE
Fix install instructions, add Makefile and memory goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: install test lint deploy clean azure-setup azure-deploy
+
+install:  ## Install all deps from GitHub + the workload in dev mode
+	pip install "agent-haymaker @ git+https://github.com/rysweet/agent-haymaker.git"
+	pip install "amplihack @ git+https://github.com/rysweet/amplihack.git"
+	pip install "amplihack-memory-lib @ git+https://github.com/rysweet/amplihack-memory-lib.git"
+	pip install -e ".[dev]"
+
+test:  ## Run pytest
+	pytest -q
+
+lint:  ## Run ruff check + format check
+	ruff check src/ tests/
+	ruff format --check src/ tests/
+
+deploy:  ## Deploy with haymaker using the example goal
+	haymaker deploy my-workload \
+		--config goal_file=goals/example-file-organizer.md \
+		--yes
+
+clean:  ## Remove .haymaker/ and __pycache__
+	rm -rf .haymaker/
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+
+azure-setup:  ## Run scripts/setup-oidc.sh (one-time Azure OIDC setup)
+	./scripts/setup-oidc.sh
+
+azure-deploy:  ## Trigger GitHub Actions deploy workflow
+	gh workflow run deploy.yml -f environment=dev

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ A goal-seeking agent workload for [Agent Haymaker](https://github.com/rysweet/ag
 ```bash
 git clone https://github.com/rysweet/haymaker-workload-starter my-workload
 cd my-workload
+
+# Install dependencies (not yet on PyPI, install from GitHub first)
+pip install "agent-haymaker @ git+https://github.com/rysweet/agent-haymaker.git"
+pip install "amplihack @ git+https://github.com/rysweet/amplihack.git"
+pip install "amplihack-memory-lib @ git+https://github.com/rysweet/amplihack-memory-lib.git"
 pip install -e ".[dev]"
 
 export ANTHROPIC_API_KEY=sk-ant-...  # or configure another SDK
@@ -50,7 +55,8 @@ The workload runs the [amplihack goal agent generator](https://rysweet.github.io
 haymaker-workload-starter/
 ├── goals/                             # Goal prompts (write yours here)
 │   ├── example-data-collector.md
-│   └── example-file-organizer.md
+│   ├── example-file-organizer.md
+│   └── example-with-memory.md
 ├── src/haymaker_my_workload/
 │   ├── __init__.py                    # Public API
 │   └── workload.py                    # Goal-agent runtime
@@ -61,6 +67,7 @@ haymaker-workload-starter/
 ├── scripts/
 │   ├── setup-oidc.sh                  # One-time Azure OIDC setup
 │   └── e2e-test.sh                    # E2E verification script
+├── Makefile                           # Dev shortcuts (make install, test, lint, deploy)
 ├── Dockerfile                         # Container image
 ├── .github/workflows/
 │   ├── ci.yml                         # Lint + test
@@ -98,7 +105,15 @@ haymaker-workload-starter/
 ## Development
 
 ```bash
+# Install dependencies (not yet on PyPI, install from GitHub first)
+pip install "agent-haymaker @ git+https://github.com/rysweet/agent-haymaker.git"
+pip install "amplihack @ git+https://github.com/rysweet/amplihack.git"
+pip install "amplihack-memory-lib @ git+https://github.com/rysweet/amplihack-memory-lib.git"
 pip install -e ".[dev]"
+
+# Or use the Makefile shortcut:
+make install
+
 pytest -q               # 21 tests
 ruff check src/ tests/  # lint
 ```

--- a/goals/example-with-memory.md
+++ b/goals/example-with-memory.md
@@ -1,0 +1,25 @@
+# Project Structure Analyzer
+
+> **Memory-enabled goal.** This goal benefits from `enable_memory=true` (the default).
+> On repeated runs the agent recalls previous analyses, tracks changes over time,
+> and refines its recommendations based on what it learned before.
+
+## Goal
+
+Analyze the project structure of the current working directory. Identify code
+organization patterns, dependency relationships, and potential improvements.
+Produce a report summarizing findings and actionable suggestions.
+
+## Constraints
+
+- Read-only: do not modify any project files
+- Focus on structure and organization, not individual code style
+- Compare with previous analysis if memory is available
+
+## Success Criteria
+
+- All top-level directories and key files catalogued
+- Dependency graph described (imports, config references)
+- At least three actionable improvement suggestions provided
+- Report written to `output/structure-report.md`
+- If prior analysis exists in memory, include a "Changes Since Last Run" section


### PR DESCRIPTION
## Summary

- **Fix install instructions (items 8-9):** The README Quick Start and Development sections previously said `pip install -e ".[dev]"` which fails because `agent-haymaker`, `amplihack`, and `amplihack-memory-lib` are not on PyPI. Both sections now show the correct sequence: install the three GitHub-hosted packages first, then `pip install -e ".[dev]"`.
- **Add Makefile (item 10):** New `Makefile` with targets: `install`, `test`, `lint`, `deploy`, `clean`, `azure-setup`, `azure-deploy`. The README Development section references `make install` as a shortcut.
- **Add memory goal example (item 11):** New `goals/example-with-memory.md` -- a project structure analysis goal that benefits from `enable_memory=true` across repeated runs. Includes a note explaining the memory benefit and a "Changes Since Last Run" success criterion.

## Test plan

- [ ] Verify `make install` runs the correct pip install sequence
- [ ] Verify `make test` runs pytest
- [ ] Verify `make lint` runs both ruff check and ruff format --check
- [ ] Verify `make deploy` invokes haymaker deploy with the example goal
- [ ] Verify `make clean` removes `.haymaker/` and `__pycache__/` dirs
- [ ] Verify README Quick Start install steps match the Makefile install target
- [ ] Verify `goals/example-with-memory.md` is a valid goal file with memory note

Generated with [Claude Code](https://claude.com/claude-code)