### PR TITLE
Raise NotImplementedError in start(), add comprehensive tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ select = ["E", "W", "F", "I", "B", "UP"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = ["integration: requires amplihack installed"]
 
 [tool.pyright]
 pythonVersion = "3.11"

--- a/src/haymaker_my_workload/workload.py
+++ b/src/haymaker_my_workload/workload.py
@@ -217,11 +217,10 @@ class MyWorkload(WorkloadBase):
 
     async def start(self, deployment_id: str) -> bool:
         """Resume is not supported -- stopped agents cannot be restarted."""
-        self.log(
+        raise NotImplementedError(
             f"Cannot resume deployment {deployment_id}. "
             "Stopped agents cannot be restarted. Deploy a new one instead."
         )
-        return False
 
     async def cleanup(self, deployment_id: str) -> CleanupReport:
         state = await self.get_status(deployment_id)


### PR DESCRIPTION
## Summary
- **`start()` now raises `NotImplementedError`** instead of silently returning `False`, making the unsupported-resume contract explicit and impossible for callers to ignore.
- **Added 24 new test cases** across 5 new test classes, bringing the total from 33 to 57 (56 unit + 1 integration).
- **Registered `integration` pytest marker** in `pyproject.toml` to suppress unknown-marker warnings.

## New test classes
| Class | Tests | What it covers |
|---|---|---|
| `TestExecuteAgentDetached` | 3 | Mock `subprocess.Popen`, verify args, missing `main.py` error |
| `TestTerminateProcess` | 4 | SIGTERM success, SIGKILL escalation, exited-noop, log handle cleanup |
| `TestDeployRejectsInvalid` | 5 | Bad SDK, high max_turns, non-bool memory, missing goal, multi-error |
| `TestValidateConfigEdgeCases` | 10 | Boundary max_turns, float/string rejection, bool checks, all SDKs, empty config |
| `TestGeneratorIntegration` | 1 | Real amplihack pipeline end-to-end (marker: `integration`) |

## Updated tests
- `TestStart.test_start_raises_not_implemented` -- expects `NotImplementedError` instead of `False`
- `TestStart.test_start_error_includes_deployment_id` -- verifies deployment ID in error message

## Test plan
- [x] `ruff check src/ tests/ --fix` -- all checks passed
- [x] `ruff format src/ tests/` -- no changes needed
- [x] `pytest -q -m "not integration"` -- 56 passed, 1 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)