### PR TITLE
Remove atexit handler that killed detached agent processes

### DIFF
--- a/src/haymaker_my_workload/workload.py
+++ b/src/haymaker_my_workload/workload.py
@@ -15,7 +15,6 @@ Configuration:
 
 from __future__ import annotations
 
-import atexit
 import logging
 import os
 import subprocess
@@ -83,7 +82,6 @@ class MyWorkload(WorkloadBase):
         self._agent_log_files: dict[str, Path] = {}
         self._log_file_handles: dict[str, IO] = {}
         self._temp_goal_files: dict[str, Path] = {}
-        atexit.register(self._kill_all_processes)
 
     async def deploy(self, config: DeploymentConfig) -> str:
         """Generate an agent from a goal prompt and execute it."""
@@ -478,14 +476,6 @@ class MyWorkload(WorkloadBase):
         lf = self._log_file_handles.pop(deployment_id, None)
         if lf and not lf.closed:
             lf.close()
-
-    def _kill_all_processes(self) -> None:
-        """atexit handler: terminate all tracked agent processes."""
-        for dep_id in list(self._processes.keys()):
-            try:
-                self._terminate_process(dep_id)
-            except Exception:
-                pass
 
     def _detect_status_from_log(self, state: DeploymentState) -> bool:
         """Check agent.log for completion indicators and update state in-place.


### PR DESCRIPTION
## Summary

Found during E2E validation: the `atexit.register(self._kill_all_processes)` in `MyWorkload.__init__` was killing the agent subprocess when the `haymaker deploy` CLI process exited. This was the root cause of agent.log always being 0 bytes -- not the fd issue.

The atexit handler sends SIGTERM to ALL tracked processes when the Python process exits. Since `haymaker deploy` exits immediately after launching the agent, the handler kills the agent before it produces any output.

## Fix

Remove the atexit handler. Agent termination is already handled by:
- `stop()` - explicit user request via `haymaker stop`
- `cleanup()` - explicit user request via `haymaker cleanup`
- `_terminate_process()` - called by stop/cleanup

The `start_new_session=True` on Popen ensures the child process survives the parent.

## E2E Validation (local)

```
$ haymaker deploy my-workload --config goal_file=goals/example-file-organizer.md --yes
Deployment started: my-workload-306625ca

$ sleep 10 && haymaker status my-workload-306625ca
  Status:   running          ← PID detection confirms alive
  Phase:    executing

$ wc -c agent.log
820 agent.log                ← Real output (was 0 before)

$ haymaker logs my-workload-306625ca
[AUTO CLAUDE] Starting auto mode (max 12 turns)
[AUTO CLAUDE] Prompt: # File Organization Agent
...
[AUTO CLAUDE] Running: claude ...
```

## Test plan

- [x] 68 unit tests pass
- [x] Local E2E: deploy returns instantly, status shows "running", agent.log has content
- [x] `haymaker logs` shows real agent AutoMode output
- [x] PID detection correctly identifies alive process

Closes #12 (fully validated this time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)