### PR TITLE
Remove polling timeout, add fast E2E goal for Azure CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,13 +201,14 @@ jobs:
           echo "Execution: $EXECUTION"
 
           # Poll for completion with periodic OIDC re-authentication.
-          # OIDC tokens expire after 5 minutes; re-auth every 4 minutes (24 iterations × 10s).
-          # We request a FRESH token from GitHub's OIDC provider each time (the static
-          # AZURE_FEDERATED_TOKEN_FILE written by azure/login is not refreshed).
+          # No timeout -- runs until the container job finishes.
+          # OIDC tokens expire after 5 minutes; re-auth every 4 minutes (24 polls × 10s).
           echo "==> Waiting for E2E job..."
-          for i in $(seq 1 480); do
+          POLL=0
+          while true; do
+            POLL=$((POLL + 1))
             # Re-authenticate every 24 polls (~4 min) to avoid OIDC token expiry
-            if [ $((i % 24)) -eq 1 ]; then
+            if [ $((POLL % 24)) -eq 1 ]; then
               FRESH_TOKEN=$(curl -sS \
                 -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
                 -H "Accept: application/json; api-version=2.0" \
@@ -226,7 +227,7 @@ jobs:
               --resource-group "$RG_NAME" \
               --job-execution-name "$EXECUTION" \
               --query "properties.status" -o tsv 2>/dev/null || echo "Unknown")
-            echo "  [$i] $STATUS"
+            echo "  [$POLL] $STATUS"
             if [ "$STATUS" = "Succeeded" ] || [ "$STATUS" = "Failed" ]; then
               break
             fi

--- a/goals/e2e-quick-test.md
+++ b/goals/e2e-quick-test.md
@@ -1,0 +1,12 @@
+# Quick E2E Test Agent
+
+## Goal
+List the files in the current directory and write a one-line summary to output/result.txt.
+
+## Constraints
+- Complete within 2 minutes
+- Read-only: do not modify existing files
+- Use only Python standard library
+
+## Success Criteria
+- output/result.txt exists and contains a file count

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -21,7 +21,7 @@ echo "--- Step 2: generator pipeline ---"
 python3 -c "
 from pathlib import Path
 from amplihack.goal_agent_generator import PromptAnalyzer, ObjectivePlanner
-goal = PromptAnalyzer().analyze(Path('goals/example-file-organizer.md'))
+goal = PromptAnalyzer().analyze(Path('goals/e2e-quick-test.md'))
 plan = ObjectivePlanner().generate_plan(goal)
 print(f'Goal: {goal.goal[:60]}...')
 print(f'Domain: {goal.domain}, Complexity: {goal.complexity}')
@@ -35,7 +35,7 @@ echo "  RUN 1: First agent execution"
 echo "=========================================="
 
 echo "--- Step 3: deploy (run 1) ---"
-OUTPUT=$(haymaker deploy my-workload --config goal_file=goals/example-file-organizer.md --config enable_memory=true --yes 2>&1)
+OUTPUT=$(haymaker deploy my-workload --config goal_file=goals/e2e-quick-test.md --config enable_memory=true --config max_turns=3 --yes 2>&1)
 echo "$OUTPUT"
 DEP1=$(echo "$OUTPUT" | grep -oE 'my-workload-[a-f0-9]+' | head -1)
 echo "Deployment ID: $DEP1"
@@ -69,7 +69,7 @@ if [ -n "$AGENT_DIR" ]; then
   echo "Agent dir: $AGENT_DIR"
   if [ -d "$AGENT_DIR" ]; then
     ls -la "$AGENT_DIR"/output/ 2>/dev/null && echo "PASS: output directory exists" || echo "WARN: no output directory"
-    cat "$AGENT_DIR"/output/file-report.md 2>/dev/null | head -20 || true
+    cat "$AGENT_DIR"/output/result.txt 2>/dev/null || cat "$AGENT_DIR"/output/file-report.md 2>/dev/null | head -20 || true
   fi
 fi
 
@@ -78,7 +78,7 @@ python3 -c "
 from amplihack_memory import ExperienceStore
 from pathlib import Path
 store = ExperienceStore(agent_name='auto_claude', storage_path=Path.home() / '.amplihack' / 'agent-memory')
-results = store.search('file organization')
+results = store.search('file')
 print(f'Memory entries: {len(results)}')
 for r in results:
     print(f'  {r.experience_type.name}: {r.context[:60]}')
@@ -99,7 +99,7 @@ echo "  RUN 2: Second execution (memory recall)"
 echo "=========================================="
 
 echo "--- Step 8: deploy (run 2, same goal) ---"
-OUTPUT2=$(haymaker deploy my-workload --config goal_file=goals/example-file-organizer.md --config enable_memory=true --yes 2>&1)
+OUTPUT2=$(haymaker deploy my-workload --config goal_file=goals/e2e-quick-test.md --config enable_memory=true --config max_turns=3 --yes 2>&1)
 echo "$OUTPUT2"
 DEP2=$(echo "$OUTPUT2" | grep -oE 'my-workload-[a-f0-9]+' | head -1)
 echo "Deployment ID: $DEP2"
@@ -123,7 +123,7 @@ python3 -c "
 from amplihack_memory import ExperienceStore
 from pathlib import Path
 store = ExperienceStore(agent_name='auto_claude', storage_path=Path.home() / '.amplihack' / 'agent-memory')
-results = store.search('file organization')
+results = store.search('file')
 print(f'Memory entries after run 2: {len(results)}')
 stats = store.get_statistics()
 print(f'Total experiences: {stats[\"total_experiences\"]}')


### PR DESCRIPTION
## Summary

- Remove the 480-iteration polling cap in the verify job. The container app job has its own `replica-timeout` (8 hours). The CI polling loop now runs until the job succeeds or fails.
- Add `goals/e2e-quick-test.md` -- a trivial goal that completes in ~2 minutes (list files, write count to output/result.txt). The file-organizer goal takes 30-45 minutes which is too slow for CI validation.
- Update `scripts/e2e-test.sh` to use the fast goal with `max_turns=3`.

## Test plan

- [x] 68 unit tests pass
- [x] Quick goal completes locally in ~2 minutes with "Goal achieved successfully!"
- [ ] Azure E2E succeeds end-to-end (will trigger after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)