### PR TITLE
Install Node.js and Claude Code CLI in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,19 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install system dependencies (git needed for pip install from GitHub)
+# Install system dependencies (git for pip, Node.js for Claude Code CLI)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl git \
+    curl git ca-certificates gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+       | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI (required by claude-agent-sdk for AutoMode)
+RUN npm install -g @anthropic-ai/claude-code
 
 # Install agent-haymaker platform and amplihack from GitHub (not yet on PyPI)
 # Install deps sequentially to avoid resolver conflicts


### PR DESCRIPTION
## Summary

Root cause of Azure E2E agents never completing: the `claude-agent-sdk` requires the `claude` CLI binary (Claude Code, an npm package) to be installed in the container. The SDK uses `SubprocessCLITransport` which calls `shutil.which("claude")` to find the binary. Without it, the agent session can't start and hangs.

The `python:3.11-slim` base image has no Node.js and no Claude Code CLI.

## Fix

- Install Node.js 22 via NodeSource apt repository
- Install `@anthropic-ai/claude-code` globally via npm

## Test plan

- [x] 68 unit tests pass
- [ ] Azure E2E: trigger after merge, verify agents complete inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)