### PR TITLE
Fix quality audit findings: dead code, wrong status, fd leak, flaky test

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -50,7 +50,11 @@ echo "  RUN 1: First agent execution"
 echo "=========================================="
 
 echo "--- Step 3: deploy (run 1) ---"
-OUTPUT=$(haymaker deploy my-workload --config goal_file=goals/e2e-quick-test.md --config enable_memory=true --config max_turns=3 --yes 2>&1)
+OUTPUT=$(haymaker deploy my-workload --config goal_file=goals/e2e-quick-test.md --config enable_memory=true --config max_turns=3 --yes 2>&1) || {
+  echo "FAIL: haymaker deploy exited with code $?"
+  echo "Output: $OUTPUT"
+  exit 1
+}
 echo "$OUTPUT"
 DEP1=$(echo "$OUTPUT" | grep -oE 'my-workload-[a-f0-9]+' | head -1)
 echo "Deployment ID: $DEP1"
@@ -165,7 +169,11 @@ echo "  RUN 2: Second execution (memory recall)"
 echo "=========================================="
 
 echo "--- Step 8: deploy (run 2, same goal) ---"
-OUTPUT2=$(haymaker deploy my-workload --config goal_file=goals/e2e-quick-test.md --config enable_memory=true --config max_turns=3 --yes 2>&1)
+OUTPUT2=$(haymaker deploy my-workload --config goal_file=goals/e2e-quick-test.md --config enable_memory=true --config max_turns=3 --yes 2>&1) || {
+  echo "FAIL: haymaker deploy (run 2) exited with code $?"
+  echo "Output: $OUTPUT2"
+  exit 1
+}
 echo "$OUTPUT2"
 DEP2=$(echo "$OUTPUT2" | grep -oE 'my-workload-[a-f0-9]+' | head -1)
 echo "Deployment ID: $DEP2"

--- a/src/haymaker_my_workload/workload.py
+++ b/src/haymaker_my_workload/workload.py
@@ -142,7 +142,7 @@ class MyWorkload(WorkloadBase):
         await self.save_state(state)
 
         # Launch agent as detached subprocess (returns immediately)
-        self._execute_agent_detached(deployment_id, agent_dir, max_turns)
+        self._execute_agent_detached(deployment_id, agent_dir)
 
         # Persist PID for cross-process status detection
         proc = self._processes.get(deployment_id)
@@ -249,9 +249,9 @@ class MyWorkload(WorkloadBase):
         if temp_file and temp_file.exists():
             temp_file.unlink()
 
-        state.status = DeploymentStatus.COMPLETED
+        state.status = DeploymentStatus.STOPPED
         state.phase = "cleaned_up"
-        state.completed_at = datetime.now(tz=UTC)
+        state.stopped_at = datetime.now(tz=UTC)
         await self.save_state(state)
 
         return CleanupReport(
@@ -262,7 +262,7 @@ class MyWorkload(WorkloadBase):
         )
 
     async def get_logs(
-        self, deployment_id: str, follow: bool = False, lines: int = 100
+        self, deployment_id: str, *, lines: int = 100, **_kwargs: object
     ) -> AsyncIterator[str]:
         state = await self.get_status(deployment_id)
 
@@ -394,7 +394,7 @@ class MyWorkload(WorkloadBase):
 
         return agent_dir
 
-    def _execute_agent_detached(self, deployment_id: str, agent_dir: Path, max_turns: int) -> None:
+    def _execute_agent_detached(self, deployment_id: str, agent_dir: Path) -> None:
         """Launch the agent as a detached subprocess (fire-and-forget)."""
         main_py = agent_dir / "main.py"
         if not main_py.exists():
@@ -402,7 +402,7 @@ class MyWorkload(WorkloadBase):
             raise FileNotFoundError(f"Agent entry point not found: {main_py}")
 
         log_file = agent_dir / "agent.log"
-        self._append_log(deployment_id, f"Executing agent (max_turns={max_turns})")
+        self._append_log(deployment_id, "Executing agent")
         self._append_log(deployment_id, f"Agent log: {log_file}")
 
         self._agent_log_files[deployment_id] = log_file
@@ -416,9 +416,17 @@ class MyWorkload(WorkloadBase):
         err_file = agent_dir / "agent.err"
         ef = open(err_file, "w", buffering=1)  # noqa: SIM115
 
-        # Create duplicate fds for the child -- survives parent GC
+        # Create duplicate fds for the child -- survives parent GC.
+        # Wrap in try/finally so the first dup is cleaned up if the second fails.
         child_stdout_fd = os.dup(lf.fileno())
-        child_stderr_fd = os.dup(ef.fileno())
+        try:
+            child_stderr_fd = os.dup(ef.fileno())
+        except OSError:
+            os.close(child_stdout_fd)
+            ef.close()
+            lf.close()
+            self._log_file_handles.pop(deployment_id, None)
+            raise
 
         # Strip CLAUDECODE env var to prevent "cannot launch inside
         # another Claude Code session" error in the agent subprocess

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -1,6 +1,5 @@
 """Tests for the goal-agent workload."""
 
-import asyncio
 import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -142,8 +141,8 @@ class TestDeploy:
             config = DeploymentConfig(workload_name="my-workload")
             dep_id = await workload.deploy(config)
             assert dep_id.startswith("my-workload-")
-            await asyncio.sleep(0.5)
             state = await workload.get_status(dep_id)
+            # Agent may still be running or already completed (mocked subprocess)
             assert state.status in (DeploymentStatus.RUNNING, DeploymentStatus.COMPLETED)
 
     async def test_deploy_with_goal_file(self, setup, tmp_path):
@@ -519,7 +518,7 @@ class TestExecuteAgentDetached:
         mock_proc.pid = 12345
 
         with patch("haymaker_my_workload.workload.subprocess.Popen", return_value=mock_proc):
-            workload._execute_agent_detached("dep-1", agent_dir, max_turns=10)
+            workload._execute_agent_detached("dep-1", agent_dir)
 
         assert "dep-1" in workload._processes
         assert workload._processes["dep-1"] is mock_proc
@@ -534,7 +533,7 @@ class TestExecuteAgentDetached:
         # No main.py
 
         with pytest.raises(FileNotFoundError, match="Agent entry point not found"):
-            workload._execute_agent_detached("dep-2", agent_dir, max_turns=5)
+            workload._execute_agent_detached("dep-2", agent_dir)
 
     def test_popen_called_with_correct_args(self, tmp_path):
         """Verify the subprocess.Popen call arguments."""
@@ -549,7 +548,7 @@ class TestExecuteAgentDetached:
         with patch(
             "haymaker_my_workload.workload.subprocess.Popen", return_value=mock_proc
         ) as mock_popen:
-            workload._execute_agent_detached("dep-3", agent_dir, max_turns=20)
+            workload._execute_agent_detached("dep-3", agent_dir)
 
         args, kwargs = mock_popen.call_args
         assert args[0] == ["python3", "-u", "main.py"]
@@ -570,7 +569,7 @@ class TestExecuteAgentDetached:
         with patch(
             "haymaker_my_workload.workload.subprocess.Popen", return_value=mock_proc
         ) as mock_popen:
-            workload._execute_agent_detached("dep-dup", agent_dir, max_turns=5)
+            workload._execute_agent_detached("dep-dup", agent_dir)
 
         _, kwargs = mock_popen.call_args
         # os.dup() returns integers, not file objects
@@ -588,7 +587,7 @@ class TestExecuteAgentDetached:
         mock_proc.pid = 55
 
         with patch("haymaker_my_workload.workload.subprocess.Popen", return_value=mock_proc):
-            workload._execute_agent_detached("dep-ef", agent_dir, max_turns=5)
+            workload._execute_agent_detached("dep-ef", agent_dir)
 
         # The error file handle should NOT be tracked (closed immediately)
         # Only the log file handle is tracked
@@ -607,7 +606,7 @@ class TestExecuteAgentDetached:
             side_effect=OSError("exec failed"),
         ):
             with pytest.raises(OSError, match="exec failed"):
-                workload._execute_agent_detached("dep-fail", agent_dir, max_turns=5)
+                workload._execute_agent_detached("dep-fail", agent_dir)
 
         # Log file handle should be cleaned up
         assert "dep-fail" not in workload._log_file_handles


### PR DESCRIPTION
## Summary

Fixes from a parallel quality audit using 3 specialized agents (code reviewer, test reviewer, infra reviewer):

- **Remove dead `follow` parameter** from `get_logs()` -- accepted but never used (Zero-BS violation)
- **Remove dead `max_turns` parameter** from `_execute_agent_detached()` -- value is already baked into generated main.py by the packager
- **Fix `cleanup()` status** -- forcibly terminated deployments now marked STOPPED, not COMPLETED
- **Fix fd leak** if second `os.dup()` fails between the two dup calls
- **Remove flaky `asyncio.sleep(0.5)`** from deploy test -- timing-dependent, breaks on slow CI
- **Add error handling** for `haymaker deploy` failures in e2e-test.sh

## Audit findings NOT fixed (accepted risks)

- Path traversal via symlinks: requires local filesystem access (already game over)
- `_read_last_line` reads full file: agent logs are small, premature optimization
- PID reuse race: known, accepted, window is negligible
- Multi-stage Docker build: nice-to-have, not a bug
- Unbounded polling: intentional design

## Test plan

- [x] 68 tests passing
- [x] Ruff clean (lint + format)
- [x] No behavioral regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)