### PR TITLE
Add timeout guards to E2E polling loops

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,11 +201,12 @@ jobs:
           echo "Execution: $EXECUTION"
 
           # Poll for completion with periodic OIDC re-authentication.
-          # No timeout -- runs until the container job finishes.
+          # Timeout after MAX_POLLS × 10s (360 × 10s = 1 hour).
           # OIDC tokens expire after 5 minutes; re-auth every 4 minutes (24 polls × 10s).
-          echo "==> Waiting for E2E job..."
+          MAX_POLLS=360
+          echo "==> Waiting for E2E job (max ${MAX_POLLS} polls / ~1 hour)..."
           POLL=0
-          while true; do
+          while [ "$POLL" -lt "$MAX_POLLS" ]; do
             POLL=$((POLL + 1))
             # Re-authenticate every 24 polls (~4 min) to avoid OIDC token expiry
             if [ $((POLL % 24)) -eq 1 ]; then
@@ -233,6 +234,11 @@ jobs:
             fi
             sleep 10
           done
+
+          if [ "$POLL" -ge "$MAX_POLLS" ] && [ "$STATUS" != "Succeeded" ] && [ "$STATUS" != "Failed" ]; then
+            echo "ERROR: Polling timed out after $MAX_POLLS polls (~1 hour). Last status: $STATUS"
+            exit 1
+          fi
 
           # Show logs
           echo "==> E2E logs:"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -111,15 +111,16 @@ for f in sorted(Path.home().glob('.haymaker/state/${DEP1}*.json')):
 " 2>/dev/null
 fi
 
-echo "--- Step 4: wait for agent to complete (polling every 60s, no limit) ---"
+echo "--- Step 4: wait for agent to complete (polling every 60s, max 120 attempts / ~2 hours) ---"
+MAX_ATTEMPTS=120
 ATTEMPT=0
-while true; do
+while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
   ATTEMPT=$((ATTEMPT + 1))
   sleep 60
   STATUS_OUTPUT=$(haymaker status "$DEP1" 2>&1)
   STATUS=$(echo "$STATUS_OUTPUT" | grep "Status:" | awk '{print $2}')
   PHASE=$(echo "$STATUS_OUTPUT" | grep "Phase:" | awk '{print $2}')
-  echo "  [$ATTEMPT] status=$STATUS phase=$PHASE ($(date -u +%H:%M:%S))"
+  echo "  [$ATTEMPT/$MAX_ATTEMPTS] status=$STATUS phase=$PHASE ($(date -u +%H:%M:%S))"
   # On first few polls, dump agent log progress
   if [ "$ATTEMPT" -le 3 ] && [ -n "$AGENT_DIR_PATH" ]; then
     echo "    agent.log: $(wc -c < "$AGENT_DIR_PATH/agent.log" 2>/dev/null || echo 0) bytes"
@@ -129,6 +130,11 @@ while true; do
     break
   fi
 done
+
+if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ] && [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ]; then
+  echo "FAIL: Run 1 polling timed out after $MAX_ATTEMPTS attempts (~2 hours). Last status=$STATUS"
+  exit 1
+fi
 
 echo "--- Step 5: show logs ---"
 haymaker logs "$DEP1" 2>&1 | tail -30 || true
@@ -178,19 +184,25 @@ echo "$OUTPUT2"
 DEP2=$(echo "$OUTPUT2" | grep -oE 'my-workload-[a-f0-9]+' | head -1)
 echo "Deployment ID: $DEP2"
 
-echo "--- Step 9: wait for run 2 to complete ---"
+echo "--- Step 9: wait for run 2 to complete (polling every 60s, max 120 attempts / ~2 hours) ---"
+MAX_ATTEMPTS=120
 ATTEMPT=0
-while true; do
+while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
   ATTEMPT=$((ATTEMPT + 1))
   sleep 60
   STATUS_OUTPUT2=$(haymaker status "$DEP2" 2>&1)
   STATUS2=$(echo "$STATUS_OUTPUT2" | grep "Status:" | awk '{print $2}')
   PHASE2=$(echo "$STATUS_OUTPUT2" | grep "Phase:" | awk '{print $2}')
-  echo "  [$ATTEMPT] status=$STATUS2 phase=$PHASE2 ($(date -u +%H:%M:%S))"
+  echo "  [$ATTEMPT/$MAX_ATTEMPTS] status=$STATUS2 phase=$PHASE2 ($(date -u +%H:%M:%S))"
   if [ "$STATUS2" = "completed" ] || [ "$STATUS2" = "failed" ]; then
     break
   fi
 done
+
+if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ] && [ "$STATUS2" != "completed" ] && [ "$STATUS2" != "failed" ]; then
+  echo "FAIL: Run 2 polling timed out after $MAX_ATTEMPTS attempts (~2 hours). Last status=$STATUS2"
+  exit 1
+fi
 
 echo "--- Step 10: check memory (run 2) ---"
 python3 -c "


### PR DESCRIPTION
## Summary
- Replaces unbounded `while true` polling loops with bounded iterations in all three E2E polling sites (fixes #24)
- `deploy.yml` verify job: `MAX_POLLS=360` (~1 hour at 10s intervals)
- `scripts/e2e-test.sh` run 1 and run 2: `MAX_ATTEMPTS=120` (~2 hours at 60s intervals)
- Each loop exits with a clear error message if the limit is reached without the job reaching a terminal state

## Test plan
- [ ] Verify `deploy.yml` syntax is valid YAML (CI will catch this)
- [ ] Verify `e2e-test.sh` syntax: `bash -n scripts/e2e-test.sh`
- [ ] Confirm polling loops terminate correctly when status reaches Succeeded/Failed before limit
- [ ] Confirm loops exit with error code 1 and a descriptive message when the limit is exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)