### PR TITLE
Adopt EventEmitterMixin: emit lifecycle events from MyWorkload

### DIFF
--- a/src/haymaker_my_workload/workload.py
+++ b/src/haymaker_my_workload/workload.py
@@ -27,6 +27,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO
 
+from agent_haymaker.events import (
+    DEPLOYMENT_COMPLETED,
+    DEPLOYMENT_FAILED,
+    DEPLOYMENT_STARTED,
+    DEPLOYMENT_STOPPED,
+)
 from agent_haymaker.workloads.base import (
     DeploymentNotFoundError,
     WorkloadBase,
@@ -151,6 +157,10 @@ class MyWorkload(WorkloadBase):
             },
         )
         await self.save_state(state)
+        try:
+            await self.emit_event(DEPLOYMENT_STARTED, deployment_id, goal_summary=goal_summary)
+        except Exception:
+            logger.debug("Failed to emit DEPLOYMENT_STARTED for %s", deployment_id)
 
         # Launch agent as detached subprocess (returns immediately)
         self._execute_agent_detached(deployment_id, agent_dir)
@@ -177,10 +187,18 @@ class MyWorkload(WorkloadBase):
                 if rc == 0:
                     state.status = DeploymentStatus.COMPLETED
                     state.phase = "completed"
+                    try:
+                        await self.emit_event(DEPLOYMENT_COMPLETED, deployment_id)
+                    except Exception:
+                        logger.debug("Failed to emit DEPLOYMENT_COMPLETED for %s", deployment_id)
                 else:
                     state.status = DeploymentStatus.FAILED
                     state.phase = "failed"
                     state.error = f"Agent exited with code {rc}"
+                    try:
+                        await self.emit_event(DEPLOYMENT_FAILED, deployment_id, error=state.error)
+                    except Exception:
+                        logger.debug("Failed to emit DEPLOYMENT_FAILED for %s", deployment_id)
                 state.completed_at = datetime.now(tz=UTC)
                 await self.save_state(state)
 
@@ -205,6 +223,10 @@ class MyWorkload(WorkloadBase):
                     state.phase = "failed"
                     state.error = "Agent process exited unexpectedly (PID no longer exists)"
                     state.completed_at = datetime.now(tz=UTC)
+                    try:
+                        await self.emit_event(DEPLOYMENT_FAILED, deployment_id, error=state.error)
+                    except Exception:
+                        logger.debug("Failed to emit DEPLOYMENT_FAILED for %s", deployment_id)
                 await self.save_state(state)
 
             elif not pid:
@@ -232,6 +254,10 @@ class MyWorkload(WorkloadBase):
         state.status = DeploymentStatus.STOPPED
         state.phase = "stopped"
         state.stopped_at = datetime.now(tz=UTC)
+        try:
+            await self.emit_event(DEPLOYMENT_STOPPED, deployment_id)
+        except Exception:
+            logger.debug("Failed to emit DEPLOYMENT_STOPPED for %s", deployment_id)
         await self.save_state(state)
         return True
 
@@ -263,6 +289,10 @@ class MyWorkload(WorkloadBase):
         state.status = DeploymentStatus.STOPPED
         state.phase = "cleaned_up"
         state.stopped_at = datetime.now(tz=UTC)
+        try:
+            await self.emit_event(DEPLOYMENT_STOPPED, deployment_id)
+        except Exception:
+            logger.debug("Failed to emit DEPLOYMENT_STOPPED for %s", deployment_id)
         await self.save_state(state)
 
         return CleanupReport(

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -5,6 +5,12 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agent_haymaker.events import (
+    DEPLOYMENT_COMPLETED,
+    DEPLOYMENT_FAILED,
+    DEPLOYMENT_STARTED,
+    DEPLOYMENT_STOPPED,
+)
 from agent_haymaker.workloads.base import DeploymentNotFoundError
 from agent_haymaker.workloads.models import (
     DeploymentConfig,
@@ -33,6 +39,7 @@ def _mock_platform():
     platform.load_deployment_state = AsyncMock(side_effect=load)
     platform.list_deployments = AsyncMock(side_effect=list_deps)
     platform.get_credential = AsyncMock(return_value=None)
+    platform.publish_event = AsyncMock()
     platform.log = MagicMock()
     platform._storage = storage
     return platform
@@ -1065,6 +1072,215 @@ class TestAppendLog:
         assert "new-dep" in wl._logs
         assert len(wl._logs["new-dep"]) == 1
         assert "first message" in wl._logs["new-dep"][0]
+
+
+class TestEventEmission:
+    """TDD tests for EventEmitterMixin integration in MyWorkload.
+
+    These tests verify that MyWorkload emits the correct events via the
+    platform event bus at lifecycle transitions (deploy, complete, fail, stop).
+    They are expected to FAIL until workload.py is updated to inherit
+    EventEmitterMixin and call emit_event at the appropriate points.
+    """
+
+    @pytest.fixture()
+    def platform(self):
+        return _mock_platform()
+
+    @pytest.fixture()
+    def workload(self, platform):
+        return MyWorkload(platform=platform)
+
+    async def test_deploy_emits_started(self, workload, platform, tmp_path):
+        """deploy() should emit DEPLOYMENT_STARTED when a deployment begins."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "main.py").write_text("import sys; sys.exit(0)\n")
+
+        mock_gen = AsyncMock(return_value=agent_dir)
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = 111
+        mock_proc.poll.return_value = None
+
+        with (
+            patch.object(workload, "_generate_agent", mock_gen),
+            patch("haymaker_my_workload.workload.subprocess.Popen", return_value=mock_proc),
+        ):
+            await workload.deploy(DeploymentConfig(workload_name="my-workload"))
+
+        # publish_event must have been called with DEPLOYMENT_STARTED topic
+        topics = [call.args[0] for call in platform.publish_event.call_args_list]
+        assert DEPLOYMENT_STARTED in topics, (
+            f"Expected {DEPLOYMENT_STARTED!r} in published topics, got {topics}"
+        )
+
+    async def test_get_status_emits_completed(self, workload, platform, tmp_path):
+        """When agent process exits with rc=0, emit DEPLOYMENT_COMPLETED."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = 0  # exited successfully
+        mock_proc.pid = 222
+
+        dep_id = "test-emit-completed"
+        workload._processes[dep_id] = mock_proc
+
+        state = DeploymentState(
+            deployment_id=dep_id,
+            workload_name="my-workload",
+            status=DeploymentStatus.RUNNING,
+            phase="executing",
+            metadata={"agent_dir": str(agent_dir)},
+        )
+        await workload.save_state(state)
+
+        await workload.get_status(dep_id)
+
+        topics = [call.args[0] for call in platform.publish_event.call_args_list]
+        assert DEPLOYMENT_COMPLETED in topics, (
+            f"Expected {DEPLOYMENT_COMPLETED!r} in published topics, got {topics}"
+        )
+
+    async def test_get_status_emits_failed(self, workload, platform, tmp_path):
+        """When agent process exits with rc!=0, emit DEPLOYMENT_FAILED."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = 1  # non-zero exit
+        mock_proc.pid = 333
+
+        dep_id = "test-emit-failed"
+        workload._processes[dep_id] = mock_proc
+
+        state = DeploymentState(
+            deployment_id=dep_id,
+            workload_name="my-workload",
+            status=DeploymentStatus.RUNNING,
+            phase="executing",
+            metadata={"agent_dir": str(agent_dir)},
+        )
+        await workload.save_state(state)
+
+        await workload.get_status(dep_id)
+
+        topics = [call.args[0] for call in platform.publish_event.call_args_list]
+        assert DEPLOYMENT_FAILED in topics, (
+            f"Expected {DEPLOYMENT_FAILED!r} in published topics, got {topics}"
+        )
+
+    async def test_get_status_pid_dead_emits_failed(self, workload, platform, tmp_path):
+        """When the PID is dead and log is inconclusive, emit DEPLOYMENT_FAILED."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "agent.log").write_text("")  # empty log -- inconclusive
+
+        dep_id = "test-emit-pid-dead"
+        state = DeploymentState(
+            deployment_id=dep_id,
+            workload_name="my-workload",
+            status=DeploymentStatus.RUNNING,
+            phase="executing",
+            metadata={"agent_dir": str(agent_dir), "agent_pid": 999999},
+        )
+        await workload.save_state(state)
+
+        with patch("haymaker_my_workload.workload.os.kill", side_effect=ProcessLookupError):
+            await workload.get_status(dep_id)
+
+        topics = [call.args[0] for call in platform.publish_event.call_args_list]
+        assert DEPLOYMENT_FAILED in topics, (
+            f"Expected {DEPLOYMENT_FAILED!r} in published topics, got {topics}"
+        )
+
+    async def test_stop_emits_stopped(self, workload, platform, tmp_path):
+        """stop() should emit DEPLOYMENT_STOPPED."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None  # still running
+        mock_proc.wait.return_value = 0
+        mock_proc.pid = 444
+
+        dep_id = "test-emit-stopped"
+        workload._processes[dep_id] = mock_proc
+
+        state = DeploymentState(
+            deployment_id=dep_id,
+            workload_name="my-workload",
+            status=DeploymentStatus.RUNNING,
+            phase="executing",
+            metadata={"agent_dir": str(agent_dir)},
+        )
+        await workload.save_state(state)
+
+        await workload.stop(dep_id)
+
+        topics = [call.args[0] for call in platform.publish_event.call_args_list]
+        assert DEPLOYMENT_STOPPED in topics, (
+            f"Expected {DEPLOYMENT_STOPPED!r} in published topics, got {topics}"
+        )
+
+    async def test_event_failure_doesnt_break_deploy(self, workload, platform, tmp_path):
+        """If publish_event raises an exception, deploy() should still succeed."""
+        platform.publish_event = AsyncMock(side_effect=RuntimeError("event bus down"))
+
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "main.py").write_text("import sys; sys.exit(0)\n")
+
+        mock_gen = AsyncMock(return_value=agent_dir)
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = 555
+        mock_proc.poll.return_value = None
+
+        with (
+            patch.object(workload, "_generate_agent", mock_gen),
+            patch("haymaker_my_workload.workload.subprocess.Popen", return_value=mock_proc),
+        ):
+            dep_id = await workload.deploy(DeploymentConfig(workload_name="my-workload"))
+
+        # deploy should succeed despite event bus failure
+        assert dep_id.startswith("my-workload-")
+
+    async def test_cleanup_running_emits_stopped(self, workload, platform, tmp_path):
+        """cleanup() emits DEPLOYMENT_STOPPED when terminating a running deployment."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None  # still running
+        mock_proc.wait.return_value = 0
+        mock_proc.pid = 666
+
+        dep_id = "test-cleanup-event"
+        workload._processes[dep_id] = mock_proc
+
+        state = DeploymentState(
+            deployment_id=dep_id,
+            workload_name="my-workload",
+            status=DeploymentStatus.RUNNING,
+            phase="executing",
+            metadata={"agent_dir": str(agent_dir)},
+        )
+        await workload.save_state(state)
+
+        await workload.cleanup(dep_id)
+
+        topics = [call.args[0] for call in platform.publish_event.call_args_list]
+        assert DEPLOYMENT_STOPPED in topics, (
+            f"Expected {DEPLOYMENT_STOPPED!r} in published topics, got {topics}"
+        )
+
+    async def test_no_platform_no_crash(self):
+        """With platform=None, emit_event should be a no-op (no crash)."""
+        workload = MyWorkload(platform=None)
+
+        # Calling emit_event directly should not raise
+        # This verifies the mixin guards on self._platform being None
+        await workload.emit_event(DEPLOYMENT_STARTED, "test-no-platform")
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Implements #18: MyWorkload now emits events at all lifecycle transition points using the `EventEmitterMixin` inherited from `WorkloadBase` (agent-haymaker PR #22).

## Events emitted

| Event | When | Method |
|-------|------|--------|
| `DEPLOYMENT_STARTED` | Deploy begins | `deploy()` |
| `DEPLOYMENT_COMPLETED` | Agent exits rc=0 | `get_status()` |
| `DEPLOYMENT_FAILED` | Agent exits rc!=0 or dead PID | `get_status()` |
| `DEPLOYMENT_STOPPED` | User terminates or cleans up | `stop()`, `cleanup()` |

## Design decisions

- **No class change**: WorkloadBase already inherits EventEmitterMixin, so MyWorkload gets `emit_event()` for free
- **Fire-and-forget**: All emissions wrapped in try/except -- event bus failures never break the workload
- **No e2e-test.sh changes**: `haymaker watch` needs a persistent event bus; polling stays for now
- **PID detection preserved**: Events complement, not replace, the existing status detection

## Step 13: Local Testing Results

**Test Environment**: worktree feat-issue-18-event-bus, 2026-03-02
**Tests Executed**:

1. Simple: Unit tests (80/80 passing) → PASS
2. Complex: Local integration test confirming emit_event called during deploy() with correct topic → PASS
   Regressions: All 72 pre-existing tests still pass → None detected

## Test plan

- [x] 80 tests passing (72 existing + 8 new event emission tests)
- [x] Ruff clean (lint + format)
- [x] Local integration test: emit_event called with DEPLOYMENT_STARTED during deploy()
- [x] Event bus failure resilience: deploy succeeds even if publish_event raises
- [x] No-platform safety: emit_event is no-op when platform=None

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)